### PR TITLE
fix path to python

### DIFF
--- a/transmission-remote-cli.py
+++ b/transmission-remote-cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 ########################################################################
 # This is transmission-remote-cli, whereas 'cli' stands for 'Curses    #
 # Luminous Interface', a client for the daemon of the BitTorrent       #


### PR DESCRIPTION
http://docs.python.org/tutorial/interpreter.html#executable-python-scripts

2.2.2. Executable Python Scripts
On BSD’ish Unix systems, Python scripts can be made directly executable, like shell scripts, by putting the line

<pre>#! /usr/bin/env python</pre>
