### PR TITLE
fix ordering of transmission-remote options

### DIFF
--- a/transmission-remote-cli.py
+++ b/transmission-remote-cli.py
@@ -2709,14 +2709,13 @@ if transmissionremote_args:
     # one argument and it doesn't start with '-' --> treat it like it's a torrent link/url
     if len(transmissionremote_args) == 1 and not transmissionremote_args[0].startswith('-'):
         cmd.extend(['-a', transmissionremote_args[0]])
-    else:
-        cmd.extend(transmissionremote_args)
 
     if config.get('Connection', 'username') and config.get('Connection', 'password'):
         cmd_print = cmd
         cmd_print.extend(['--auth', '%s:PASSWORD' % config.get('Connection', 'username')])
         print "EXECUTING:\n%s\nRESPONSE:" % ' '.join(cmd_print)
         cmd.extend(['--auth', '%s:%s' % (config.get('Connection', 'username'), config.get('Connection', 'password'))])
+        cmd.extend(transmissionremote_args)
     else:
         print "EXECUTING:\n%s\nRESPONSE:" % ' '.join(cmd)
 


### PR DESCRIPTION
I found that I wasn't able to forward arguments to transmission-remote properly because the auth options must come first before any command arguments, such as '-l'.  This fixes the ordering and works for me using transmission-remote-cli on osx lion communcating with transmission-daemon 2.42 running on ubuntu natty.
