### PR TITLE
More comfortable cursor movement in input dialog text area.

### DIFF
--- a/transmission-remote-cli.py
+++ b/transmission-remote-cli.py
@@ -2226,11 +2226,15 @@ class Interface:
                 index += 1
             elif c == curses.KEY_LEFT and index > 0:
                 index -= 1
-            elif c == curses.KEY_BACKSPACE and index > 0:
+            elif (c == curses.KEY_BACKSPACE or c == 127) and index > 0:
                 input = input[:index - 1] + (index < len(input) and input[index:] or '')
                 index -= 1
             elif c == curses.KEY_DC and index < len(input):
                 input = input[:index] + input[index + 1:]
+            elif c == curses.KEY_HOME and index > 0:
+                index = 0
+            elif c == curses.KEY_END and index < len(input):
+                index = len(input)
             elif c == ord('\n'):
                 return input
             elif c >= 32 and c < 127 and len(input) + 1 < self.width - 7:


### PR DESCRIPTION
Add HOME/END keys to jump directly to the beginning/end of the text
field. curses.BACKSPACE didn't match with the actual keycode that was
sent by my backspace key (the docs claim that this constant is
unreliable), so add ASCII code 127 (DEL) to the BACKSPACE event as well.
