### PR TITLE
Allow more text in input dialog field.

### DIFF
--- a/transmission-remote-cli.py
+++ b/transmission-remote-cli.py
@@ -2226,6 +2226,7 @@ class Interface:
 
     def dialog_input_text(self, message, input='', on_change=None, on_enter=None):
         width  = self.width - 4
+        textwidth = self.width - 8
         height = message.count("\n") + 4
 
         win = self.window(height, width, message=message)
@@ -2233,9 +2234,15 @@ class Interface:
         curses.curs_set(1)  # make cursor visible
         index = len(input)
         while True:
+            # Cut the text into pages, each as long as the text field
+            # The current page is determined by index position
+            page = index // textwidth
+            displaytext = input[textwidth*page:textwidth*(page + 1)]
+            displayindex = index - textwidth*page
+
             color = (curses.color_pair(11) if self.highlight_dialog else curses.color_pair(5))
-            win.addstr(height - 2, 2, input.ljust(width - 4), color)
-            win.move(height - 2, index + 2)
+            win.addstr(height - 2, 2, displaytext.ljust(textwidth), color)
+            win.move(height - 2, displayindex + 2)
             c = win.getch()
             if c == 27 or c == curses.KEY_BREAK:
                 curses.curs_set(0)
@@ -2264,7 +2271,7 @@ class Interface:
                 else:
                     curses.curs_set(0)
                     return input
-            elif c >= 32 and c < 127 and len(input) + 1 < self.width - 7:
+            elif c >= 32 and c < 127:
                 input = input[:index] + chr(c) + (index < len(input) and input[index:] or '')
                 index += 1
                 if on_change: on_change(input)


### PR DESCRIPTION
The amount of text that can be entered in the input dialog is currently
capped at whatever can be displayed at a time, i.e. a few characters less
than the console width. This is often insufficient when a torrent should
be added via URL at standard terminal sizes.

This commit introduces paging for the input text field. The input string
is split into pages, each as long as the width of the text field. The
"page" displayed is dependant on cursor position. This only affects text
and cursor drawing, i.e. only a certain portion of the original string
will be passed to addstr.
