### PR TITLE
Compact torrent list view and tracker editing in tracker details pane.

### DIFF
--- a/transmission-remote-cli.py
+++ b/transmission-remote-cli.py
@@ -1890,19 +1890,23 @@ class Interface:
         def addstr(ypos, xpos, *args):
             if ypos > top and ypos < self.height - 2:
                 self.pad.addstr(ypos, xpos, *args)
-        tlist = self.torrent_details['trackerStats']
-        ypos -= self.scrollpos_detaillist % self.TRACKER_ITEM_HEIGHT
-        start = self.scrollpos_detaillist / self.TRACKER_ITEM_HEIGHT
-        tlist = tlist[start:]
+
+        tracker_per_page = self.detaillistitems_per_page // self.TRACKER_ITEM_HEIGHT
+        page = self.scrollpos_detaillist // tracker_per_page
+        start = tracker_per_page * page
+        end = tracker_per_page * (page + 1)
+        tlist = self.torrent_details['trackerStats'][start:end]
+
         current_tier = -1
         for index, t in enumerate(tlist):
             announce_msg_size = scrape_msg_size = 0
+            selected = t == self.torrent_details['trackerStats'][self.scrollpos_detaillist]
 
             if current_tier != t['tier']:
                 current_tier = t['tier']
 
                 tiercolor = curses.A_BOLD + curses.A_REVERSE \
-                            if index == self.scrollpos_detaillist else curses.A_REVERSE
+                            if selected else curses.A_REVERSE
                 addstr(ypos, 0, ("Tier %d" % (current_tier+1)).ljust(self.width), tiercolor)
                 ypos += 1
 


### PR DESCRIPTION
I kind of messed up the commit order, and could not find a way to separate commits from the two features (maybe cherry-pick, but apparently I suck at GitHub'ing).
## Compact torrent list

a09b8c7e6d1a4c0cb896d083dd2a29801ccab468 and 5ba6ef81cd731ba2aeda98db26654c5440c21286 enable toggling of a compact torrent view mode (issue #39). I missed various points where `3` was hardcoded for item height at first, thus the second commit. Pressing 'C' should switch to a condensed view of the torrent list view, which appears to be useful when many torrents are running at once.
## Edit trackers

Other commits enable 'a' and 'r' for adding and removing trackers in the tracker pane, respectively (issue #14). To keep complexity down (_cough_ lazy), I slightly changed scrolling behavior in trackers/peers/pieces. Apparently, the scrolling code prevented users from scrolling "past" the last item, so the internal index tracking the selected item would only be changed if pressing UP/DOWN/... resulted in a scrolling operation. In case of trackers, this would mean that at least three or four trackers would have to be present (at 80x24) to trigger any scrolling at all. I removed this protection, so that a user can now scroll down until the last item is reached.

This change greatly simplifies tracking the selected item, but then again, scrolling to the last item in a long list now shows only this item on top of the screen, instead of the item at last position without any blank space below. Maybe this could be fixed in one of the `draw_` methods, but I didn't investigate too deeply.
