### PR TITLE
Scroll peer and pieces view line-by-line.

### DIFF
--- a/transmission-remote-cli.py
+++ b/transmission-remote-cli.py
@@ -1895,14 +1895,13 @@ class Interface:
                 except adns.Error, msg:
                     host_name = msg
 
-            selected = peer == self.torrent_details['peers'][self.scrollpos_detaillist]
             upload_tag = download_tag = line_tag = 0
             if peer['rateToPeer']:   upload_tag   = curses.A_BOLD
             if peer['rateToClient']: download_tag = curses.A_BOLD
 
             self.pad.move(ypos, 0)
             # Flags
-            self.pad.addstr("%-6s   " % peer['flagStr'], curses.A_BOLD if selected else 0)
+            self.pad.addstr("%-6s   " % peer['flagStr'])
             # Down
             self.pad.addstr("%5s  " % scale_bytes(peer['rateToClient']), download_tag)
             # Up


### PR DESCRIPTION
I've been brooding over this issue for a while, but (to my great shame) couldn't come up with a good way to add natural scrolling without either introducing a new class variable, or limiting `scrollpos_detaillist` pretty much in the way it was limited before my commits. So, I opted for the latter in the end. This means that items at the end of the peer list might not be selectable im some cases. This is acceptable for now, as peers aren't supposed to be selectable anyway, but should be kept in mind in case any such functionality is added in the future.
