### PR TITLE
Replace upload rate with seed ratio in compact mode (if upspeed = 0)

### DIFF
--- a/transmission-remote-cli.py
+++ b/transmission-remote-cli.py
@@ -1510,6 +1510,10 @@ class Interface:
 
             return 3 # number of lines that were used for drawing the list item
         else:
+            # Draw ratio in place of upload rate if upload rate = 0
+            if not torrent['rateUpload']:
+                self.draw_ratio(torrent, y - 1)
+
             return 1
 
     def draw_downloadrate(self, torrent, ypos):


### PR DESCRIPTION
If a torrent's upload speed is currently zero, display the seed ratio
instead. This seems to be a good compromise between space conservation
in compact mode and availability of information, since the upload speed bar
would normally be empty when not uploading, thus being largely useless.
