### PR TITLE
Fix UnicodeEncodeError with torrent['errorString']

### DIFF
--- a/transmission-remote-cli.py
+++ b/transmission-remote-cli.py
@@ -1596,7 +1596,7 @@ class Interface:
         if torrent['errorString'] and \
                 not torrent['seeders'] and not torrent['leechers'] and \
                 not torrent['status'] == Transmission.STATUS_STOPPED:
-            parts[0] = torrent['errorString']
+            parts[0] = torrent['errorString'].encode('utf-8')
 
         else:
             if torrent['status'] == Transmission.STATUS_CHECK:


### PR DESCRIPTION
This fixes a exception when the errorString contains non-ascii characters like:
"Torrent non enregistré"
