### PR TITLE
Focus next torrent after removing another.

### DIFF
--- a/transmission-remote-cli.py
+++ b/transmission-remote-cli.py
@@ -1198,6 +1198,10 @@ class Interface:
                     self.details_category_focus = 0
                 server.remove_torrent(self.torrents[self.focus]['id'])
 
+                # Focus the the next available torrent
+                new_focus = min(self.focus + 1, len(self.torrents) - 1)
+                self.focused_id = self.torrents[new_focus]['id']
+
     def remove_torrent_local_data(self, c):
         if self.focus > -1:
             name = self.torrents[self.focus]['name'][0:self.width - 15]
@@ -1207,6 +1211,10 @@ class Interface:
                     self.selected_torrent = -1
                     self.details_category_focus = 0
                 server.remove_torrent_local_data(self.torrents[self.focus]['id'])
+
+                # Focus the the next available torrent
+                new_focus = min(self.focus + 1, len(self.torrents) - 1)
+                self.focused_id = self.torrents[new_focus]['id']
 
     def add_tracker(self):
         if server.get_rpc_version() < 10:


### PR DESCRIPTION
Resetting the focus each time a torrent is removed quickly
becomes a hassle when trying to remove multiple torrents.

This commit changes the focus to the torrent after the previously
removed one.

When removing the last torrent, self.focused_id is set to the torrent
that is about to be removed. This shouldn't be a problem, however,
as follow_list_focus() ignores invalid focused_id values.
