### PR TITLE
Toggling compact mode does not update self.scrollpos.

### DIFF
--- a/transmission-remote-cli.py
+++ b/transmission-remote-cli.py
@@ -889,11 +889,9 @@ class Interface:
         self.manage_layout()
 
     def manage_layout(self):
-        self.tlist_item_height = 3 if not self.compact_list else 1
+        self.recalculate_torrents_per_page()
         self.pad_height = max((len(self.torrents)+1) * self.tlist_item_height, self.height)
         self.pad = curses.newpad(self.pad_height, self.width)
-        self.mainview_height = self.height - 2
-        self.torrents_per_page = self.mainview_height / self.tlist_item_height
         self.detaillistitems_per_page = self.height - 8
 
         if self.selected_torrent > -1:
@@ -930,6 +928,10 @@ class Interface:
         new_width = max(self.rateUpload_width, new_width) # don't shrink
         return new_width
 
+    def recalculate_torrents_per_page(self):
+        self.tlist_item_height = 3 if not self.compact_list else 1
+        self.mainview_height = self.height - 2
+        self.torrents_per_page = self.mainview_height / self.tlist_item_height
 
     def run(self):
         self.draw_title_bar()
@@ -1387,6 +1389,8 @@ class Interface:
 
     def toggle_compact_torrentlist(self, c):
         self.compact_list = not self.compact_list
+        self.recalculate_torrents_per_page()
+        self.follow_list_focus()
 
     def move_torrent(self, c):
         if self.focus > -1:


### PR DESCRIPTION
self.scrollpos shows how many lines have been scrolled down, in
torrent line sizes. That is, five torrents are loaded and only four are
visible, scrolling down the the last torrent would set scrollpos to 3 in
normal mode (size of one torrent), but only 1 in compact mode.

Clearly, scrollpos should be updated whenever the user switches to
ensure that a) the previously focused torrent is still visible and b)
scrollpos doesn't cause invalid array access in e.g. visible torrents
calculation.

follow_list_focus() seems to be perfect for that, however, it depends on
manage_layout() to set self.torrents_per_page and self.tlist_item_height.

So, refactor torrents per page calculation out of manage_layout(), and call
new method within toggle_compact_mode() to ensure that self.scrollpos is
always valid.

This commit fixes fagga/transmission-remote-cli#62.
