### PR TITLE
Wrong progress bar placement calculation for kanji.

### DIFF
--- a/transmission-remote-cli
+++ b/transmission-remote-cli
@@ -1613,7 +1613,7 @@ class Interface:
             # terminal, so we have to catch this exception.
             try:
                 self.pad.addstr(ypos, 0, title[0:bar_width].encode('utf-8'), tag_done)
-                self.pad.addstr(ypos, bar_width, title[bar_width:].encode('utf-8'), tag)
+                self.pad.addstr(ypos, len_columns(title[0:bar_width]), title[bar_width:].encode('utf-8'), tag)
             except:
                 pass
         else:


### PR DESCRIPTION
The progress bar is drawn in two steps, first drawing the bar and
then the remaining text portion. However, the second step doesn't
take into calculation that the first drawing operation could draw
more columns than characters (i.e. one kanji is drawn in two columns).

This often mangles the filename by overwriting the first bar with the
start of the second bar.
