### PR TITLE
Indicate all trackers are down by coloring torrent line red

### DIFF
--- a/transmission-remote-cli
+++ b/transmission-remote-cli
@@ -728,7 +728,7 @@ class Transmission:
             status = 'unknown state'
         return status
 
-    def get_tracker_responding(self, torrent):
+    def is_tracker_responding(self, torrent):
         """ Will return True if at least one tracker was successfully
         queried recently. Returns True if torrent does not have any
         trackers (DHT?). """
@@ -1619,7 +1619,7 @@ class Interface:
         size = '| ' + size
         title = ljust_columns(torrent['name'], width - len(size)) + size
 
-        if not server.get_tracker_responding(torrent) \
+        if not server.is_tracker_responding(torrent) \
             and torrent['status'] != Transmission.STATUS_STOPPED:
             color = curses.color_pair(self.colors.get_id('title_error'))
         elif torrent['status'] == Transmission.STATUS_SEED \


### PR DESCRIPTION
I am in a situation where I am seeding a good amount of torrents for an extended period of time. As it stands, trackers often change ports, locations or go down for good, which in turn requires that associated torrents must be re-downloaded with updated tracker information. Right now, transmission-remote-cli doesn't seem to provide a good visual indicaton when a torrent is effectively dead, and the user has to check the tracker page for each torrent individually.

The idea here is to add a new color indicating tracker error (I chose red background and white foreground, but this just a suggestion), and color a torrent line differently if its trackers cannot be reached. Thus, defunct torrents can be easily detected just by looking at the torrent list overview.

Essentially, a torrent is considered defective if none of its trackers provide a successful scrape or announce. I originally planned to query only `lastScrapeSucceeded`, but then decided to use either `lastAnnounceSucceeded` or `lastScrapeSucceeded`, depending on which was done more recently (`lastScrapeTime` vs. `lastAnnounceTime`). I'm not perfectly certain this is the best way to approach the problem, as I'm not well versed in the BitTorrent protocol, but it seems to provide reasonable results.
