### PR TITLE
Message dialog can crash when too many lines are printed.

### DIFF
--- a/transmission-remote-cli
+++ b/transmission-remote-cli
@@ -2484,8 +2484,14 @@ class Interface:
         for line in message.split("\n"):
             if len_columns(line) > width:
                 line = ljust_columns(line, width-7) + '...'
-            win.addstr(ypos, 2, line.encode('utf-8'))
-            ypos += 1
+
+            if ypos < height - 1:  # ypos == height-1 is frame border
+                win.addstr(ypos, 2, line.encode('utf-8'))
+                ypos += 1
+            else:
+                # Do not write outside of frame border
+                win.addstr(ypos, 2, " More... ")
+                break
         return win
 
 


### PR DESCRIPTION
The message window created by window() does not check for its
own height when adding lines of text. Because of this, too many lines
in conjunction with a small window can lead to program crash. The help
dialog is a good example.

Instead of writing outside of the window's allocated height, inform the
user that the window contains more text (by adding "More..." to the
dialog border on the lower left) and stop writing more text.
