### PR TITLE
Try to open focused file with xdg-open

### DIFF
--- a/transmission-remote-cli
+++ b/transmission-remote-cli
@@ -1470,7 +1470,8 @@ class Interface:
     def open_torrent_file(self, c):
         if self.focus_detaillist >= 0:
             details = server.get_torrent_details()
-            file_name = details['files'][self.focus_detaillist]['name']
+            file_server_index = self.file_index_map[self.focus_detaillist]
+            file_name = details['files'][file_server_index]['name']
             download_dir = details['downloadDir']
 
             devnull = open(os.devnull, 'wb')


### PR DESCRIPTION
While in the "Files" view of a torrent's Details, hitting enter on a
focused file will execute the following command, in a nonblocking
manner:

```
xdg-open <focused file's path>
```

This will, of course, not work if the client is not launched from the
same machine as the server, because it isn't the same file structure.
If, that is the case, the operation will fail silently. On the other
hand, if the user has the current torrent files on the "client" machine
with the same path as the server, he may be amazed as how
"transmission-remote-cli" figured out where his file was. :)
