### PR TITLE
Timestamp function fails on timestamps larger than sys.maxint (crashing torrent detail page)

### DIFF
--- a/transmission-remote-cli
+++ b/transmission-remote-cli
@@ -3116,7 +3116,7 @@ def timestamp(timestamp, format="%x %X"):
     if timestamp < 1:
         return 'never'
 
-	if timestamp > 2**31:  # Max value of 32bit signed integer
+    if timestamp > 2**31:  # Max value of 32bit signed integer
         # Timedelta objects do not fail on timestamps
         # resulting in a date later than 2038
         date = (datetime.datetime.fromtimestamp(0) +


### PR DESCRIPTION
The timestamp function uses time.localtime to convert a timestamp
to a time object. According to the Python docs, this module falls
back to C library functions that handle int-sized values only (i.e.
up to the year 2038). If values larger than sys.maxint are passed,
the function throws an exception (at least on my x86 system).

Now, apparently, in some cases the ratio estimation can come up with
interesting values, such as reaching ratio 990 sometimes in 2077,
which would result in trc crashing when viewing the torrent detail
page.

Work around this issue by using the datetime module in cases timestamp
is larger than sys.maxint. datetime.timedelta does not use C library
functions and handles large values. By adding the timedelta to a
datetime object, a new datetime object is created which is then
converted to a normal time object.
