### PR TITLE
Adds hability to copy magnet links to the clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ packaged in any Linux distribution. The Debian/Ubuntu package is called
 
 - GeoIP: Guess which country peers come from.
 - adns: Resolve IPs to host names.
-- [xerox](https://pypi.python.org/pypi/xerox): Copy magnet links to the system clipboard.
+- [xerox](https://pypi.python.org/pypi/xerox): Copy magnet links to the system clipboard. You will also need either xclip on linux or pbcopy on OS X for this to work.
 
 Debian/Ubuntu package names are `python-adns` and `python-geoip`.
 

--- a/transmission-remote-cli
+++ b/transmission-remote-cli
@@ -1412,7 +1412,11 @@ class Interface:
             try:
                 xerox.copy(magnet)
             except xerox.ToolNotFound:
-                self.dialog_ok('Could not copy to the clipboard')
+                message  = 'Could not copy to the clipboard\n'
+                message += 'You probably do not have an appropriate\n'
+                message += 'tool to handle the clipboard on your system.\n'
+                message += 'Refer to the xerox documentation.'
+                self.dialog_ok(message)
 
     def move_queue(self, direction):
         # queue was implemmented in Transmission v2.4


### PR DESCRIPTION
This adds a new keybind, M, to copy magnet links to the clipboard.

I implemented this for personal use and I am not entirely convinced that it belongs "upstream", especially because of the second point. But decided to submit it anyway.
- Magnet links were incorporated in Transmission 1.8 (RPC 7). Since TRNSM_VERSION_MIN and RPC_VERSION_MIN are set to '1.90' and 8 respectively then I thought that this would not be a problem. If it is, then it would be pretty easy to disable this feature on older transmission versions and not cause any problem for then.
- I used an external library, [xerox](https://pypi.python.org/pypi/xerox), to handle the system clipboard. I did this because I did not find any native and portable way to archive this (this library claims to works on linux, mac and windows, I only tested it on linux). If anyone knows a more "popular" library to do this, then this could easily be changed. If there are multiple alternatives we could even use some kind of fallback mechanism (like the way is done with simplejson).
