### PR TITLE
Insane ratios throw exceptions

### DIFF
--- a/transmission-remote-cli
+++ b/transmission-remote-cli
@@ -2180,6 +2180,8 @@ class Interface:
             if time_left < 86400:   # 1 day
                 info[-1].append('approaching %.2f at %s' % \
                                     (target_ratio, timestamp(time.time() + time_left, "%R")))
+            elif time_left > 86400 * 10000: # 10,000 days
+                info[-1].append('approaching %.2f at (>10000 days)' % target_ratio)
             else:
                 info[-1].append('approaching %.2f on %s' % \
                                     (target_ratio, timestamp(time.time() + time_left, "%x")))


### PR DESCRIPTION
In the case where a torrent has insane ratios, timestamp(X,"%R") throws an overflow error on the number of days remaining.

These commits:
- show an error message on an exception, so the exception's source can be tracked down
- skip showing the exact days left if it's more than 10,000

Torrent's data that caused this:
    Download: 123 [0.1K](0%) received;  17,522,056,398 [16.32G](100%) verified;  nothing corrupt
      Upload: 251,914,377,236 [234.61G](204808435200%) transmitted; sending 200,000 [195K] per second
       Ratio: 14.38 copies distributed;  approaching 2048084360.00 at (>10000 days)
