### PR TITLE
Get the source code closer to working for python 3.

### DIFF
--- a/transmission-remote-cli
+++ b/transmission-remote-cli
@@ -45,11 +45,8 @@ import time
 import datetime
 import re
 import base64
-import httplib
-import urllib2
 import socket
 socket.setdefaulttimeout(None)
-import ConfigParser
 from optparse import OptionParser, SUPPRESS_HELP
 import sys
 import os
@@ -62,8 +59,28 @@ from textwrap import wrap
 from subprocess import call, Popen
 import netrc
 import operator
-import urlparse
 from distutils.spawn import find_executable
+
+try:
+    import httplib
+except ImportError:
+    import http.client
+
+try:
+    import urllib2
+except ImportError:
+    import urllib.request as urllib2
+
+try:
+    import ConfigParser
+except ImportError:
+    import configparser as ConfigParser
+
+try:
+    import urlparse
+except ImportError:
+    import urllib.parse as urlparse
+
 
 locale.setlocale(locale.LC_ALL, '')
 ENCODING = locale.getpreferredencoding() or 'UTF-8'

--- a/transmission-remote-cli
+++ b/transmission-remote-cli
@@ -15,6 +15,7 @@
 # GNU General Public License for more details:                         #
 # http://www.gnu.org/licenses/gpl-3.0.txt                              #
 ########################################################################
+from __future__ import print_function
 
 VERSION = '1.7.0'
 
@@ -997,8 +998,7 @@ class Interface(object):
             self.run()
         except curses.error:
             self.restore_screen()
-            (exc_type, exc_value, exc_traceback) = sys.exc_info()
-            raise exc_type, exc_value, exc_traceback
+            raise
         else:
             self.restore_screen()
 
@@ -1024,7 +1024,7 @@ class Interface(object):
         except KeyError:
             pass
 
-        signal.signal(signal.SIGWINCH, lambda y,frame: self.get_screen_size())
+        signal.signal(signal.SIGWINCH, lambda y, frame: self.get_screen_size())
         self.get_screen_size()
 
     def restore_screen(self):
@@ -3583,7 +3583,7 @@ def quit(msg='', exitcode=0):
     if not msg and not exitcode:
         save_config(cmd_args.configfile)
     else:
-        print >> sys.stderr, msg,
+        print(msg, file=sys.stderr)
     os._exit(exitcode)
 
 
@@ -3632,9 +3632,9 @@ def read_netrc(file=os.environ['HOME'] + '/.netrc', hostname=None):
             netrc.netrc(file).hosts[hostname]
         except KeyError:
             if hostname != 'localhost':
-                print "Unknown machine in %s: %s" % (file, hostname)
+                print("Unknown machine in %s: %s" % (file, hostname))
                 if login and password:
-                    print "Using default login: %s" % login
+                    print("Using default login: %s" % login)
                 else:
                     exit(CONFIGFILE_ERROR)
     except netrc.NetrcParseError as e:
@@ -3662,13 +3662,13 @@ def create_config(option, opt_str, value, parser):
         try:
             os.makedirs(dir)
         except OSError as msg:
-            print msg
+            print(msg)
             exit(CONFIGFILE_ERROR)
 
     # write file
     if not save_config(configfile, force=True):
         exit(CONFIGFILE_ERROR)
-    print "Wrote config file: %s" % configfile
+    print("Wrote config file: %s" % configfile)
     exit(0)
 
 
@@ -3676,10 +3676,11 @@ def save_config(filepath, force=False):
     if force or os.path.isfile(filepath):
         try:
             config.write(open(filepath, 'w'))
-            os.chmod(filepath, 0600)  # config may contain password
+            os.chmod(filepath, 0o600)  # config may contain password
             return 1
         except IOError as msg:
-            print >> sys.stderr, "Cannot write config file %s:\n%s" % (filepath, msg)
+            print("Cannot write config file %s:\n%s" % (filepath, msg),
+                  file=sys.stderr)
             return 0
     return -1
 
@@ -3755,10 +3756,10 @@ if __name__ == '__main__':
         if config.get('Connection', 'username') and config.get('Connection', 'password'):
             cmd_print = cmd
             cmd_print.extend(['--auth', '%s:PASSWORD' % config.get('Connection', 'username')])
-            print "EXECUTING:\n%s\nRESPONSE:" % ' '.join(cmd_print)
+            print("EXECUTING:\n%s\nRESPONSE:" % ' '.join(cmd_print))
             cmd.extend(['--auth', '%s:%s' % (config.get('Connection', 'username'), config.get('Connection', 'password'))])
         else:
-            print "EXECUTING:\n%s\nRESPONSE:" % ' '.join(cmd)
+            print("EXECUTING:\n%s\nRESPONSE:" % ' '.join(cmd))
 
         try:
             retcode = call(cmd)

--- a/transmission-remote-cli
+++ b/transmission-remote-cli
@@ -233,7 +233,7 @@ class TransmissionRequest(object):
             pass
 
         # authentication
-        except urllib2.HTTPError, e:
+        except urllib2.HTTPError as e:
             try:
                 msg = html2text(str(e.read()))
             except:
@@ -247,7 +247,7 @@ class TransmissionRequest(object):
             except AttributeError:
                 quit(str(msg) + "\n", CONNECTION_ERROR)
 
-        except urllib2.URLError, msg:
+        except urllib2.URLError as msg:
             try:
                 reason = msg.reason[1]
             except IndexError:
@@ -1782,7 +1782,7 @@ class Interface(object):
                     devnull = open(os.devnull, 'wb')
                     Popen(viewer_cmd, stdout=devnull, stderr=devnull)
                     devnull.close()
-            except OSError, err:
+            except OSError as err:
                 self.get_screen_size()
                 self.dialog_ok("%s:\n%s" % (" ".join(viewer_cmd), err))
 
@@ -2456,7 +2456,7 @@ class Interface(object):
                         host_name = "<not resolvable>"
                 except adns.NotReady:
                     host_name = "<resolving>"
-                except adns.Error, msg:
+                except adns.Error as msg:
                     host_name = msg
 
             upload_tag = download_tag = line_tag = 0
@@ -3046,7 +3046,7 @@ class Interface(object):
                 index += 1
                 if on_change: on_change(input)
             elif c == ord('\t') and tab_complete:
-                possible_choices = [];
+                possible_choices = []
                 if tab_complete in ('files', 'dirs'):
                     (dirname, filename) = os.path.split(tilde2homedir(input))
                     if not dirname:
@@ -3055,7 +3055,7 @@ class Interface(object):
                         possible_choices = [ os.path.join(dirname, choice) for choice in os.listdir(dirname)
                                              if choice.startswith(filename) ]
                     except OSError:
-                        continue;
+                        continue
                     if tab_complete == 'dirs':
                         possible_choices = [ d for d in possible_choices
                                              if os.path.isdir(d) ]
@@ -3069,7 +3069,7 @@ class Interface(object):
                             input += os.sep
                         input = homedir2tilde(input)
                     index = len(input)
-                    if on_change: on_change(input);
+                    if on_change: on_change(input)
             if on_change: win.redrawwin()
 
     def dialog_search_torrentlist(self, c):
@@ -3637,9 +3637,9 @@ def read_netrc(file=os.environ['HOME'] + '/.netrc', hostname=None):
                     print "Using default login: %s" % login
                 else:
                     exit(CONFIGFILE_ERROR)
-    except netrc.NetrcParseError, e:
+    except netrc.NetrcParseError as e:
         quit("Error in %s at line %s: %s\n" % (e.filename, e.lineno, e.msg))
-    except IOError, msg:
+    except IOError as msg:
         quit("Cannot read %s: %s\n" % (file, msg))
     return login, password
 
@@ -3661,7 +3661,7 @@ def create_config(option, opt_str, value, parser):
     if dir != '' and not os.path.isdir(dir):
         try:
             os.makedirs(dir)
-        except OSError, msg:
+        except OSError as msg:
             print msg
             exit(CONFIGFILE_ERROR)
 
@@ -3678,7 +3678,7 @@ def save_config(filepath, force=False):
             config.write(open(filepath, 'w'))
             os.chmod(filepath, 0600)  # config may contain password
             return 1
-        except IOError, msg:
+        except IOError as msg:
             print >> sys.stderr, "Cannot write config file %s:\n%s" % (filepath, msg)
             return 0
     return -1
@@ -3762,7 +3762,7 @@ if __name__ == '__main__':
 
         try:
             retcode = call(cmd)
-        except OSError, msg:
+        except OSError as msg:
             quit("Could not execute the above command: %s\n" % msg.strerror, 128)
         quit('', retcode)
 


### PR DESCRIPTION
All of the changes are portable and should work in both python 2 and 3. It is still not fully working for python 3 but it is a bit closer. If anything... it is good practice to write code that works in both python 2 and 3.

For this part:
```diff
    self.run()
except curses.error:
     self.restore_screen()
--- (exc_type, exc_value, exc_traceback) = sys.exc_info()
--- raise exc_type, exc_value, exc_traceback
+++ raise
```
I believe the intention was just to restore the screen before re-raising the same exception. `raise` with no arguments does that exactly. Also the previous method did not work for python 3.