### PR TITLE
Un-reverse colors to get transparent backgrounds

### DIFF
--- a/transmission-remote-cli
+++ b/transmission-remote-cli
@@ -148,16 +148,16 @@ config.set('Colors', 'title_seed',       'bg:green,fg:black')
 config.set('Colors', 'title_download',   'bg:blue,fg:black')
 config.set('Colors', 'title_idle',       'bg:cyan,fg:black')
 config.set('Colors', 'title_verify',     'bg:magenta,fg:black')
-config.set('Colors', 'title_paused',     'bg:black,fg:white')
-config.set('Colors', 'title_error',      'bg:red,fg:white')
-config.set('Colors', 'download_rate',    'bg:black,fg:blue')
-config.set('Colors', 'upload_rate',      'bg:black,fg:red')
-config.set('Colors', 'eta+ratio',        'bg:black,fg:white')
+config.set('Colors', 'title_paused',     'bg:,fg:')
+config.set('Colors', 'title_error',      'bg:red,fg:')
+config.set('Colors', 'download_rate',    'bg:,fg:blue')
+config.set('Colors', 'upload_rate',      'bg:,fg:red')
+config.set('Colors', 'eta+ratio',        'bg:,fg:')
 config.set('Colors', 'filter_status',    'bg:red,fg:black')
-config.set('Colors', 'dialog',           'bg:black,fg:white')
+config.set('Colors', 'dialog',           'bg:,fg:')
 config.set('Colors', 'dialog_important', 'bg:red,fg:black')
 config.set('Colors', 'button',           'bg:white,fg:black')
-config.set('Colors', 'button_focused',   'bg:black,fg:white')
+config.set('Colors', 'button_focused',   'bg:,fg:')
 config.set('Colors', 'file_prio_high',   'bg:red,fg:black')
 config.set('Colors', 'file_prio_normal', 'bg:white,fg:black')
 config.set('Colors', 'file_prio_low',    'bg:yellow,fg:black')
@@ -179,11 +179,8 @@ class ColorManager(object):
                                  self.config[name]['bg'])
 
     def _parse_color_pair(self, pair):
-        # BG and FG are intentionally switched here because colors are always
-        # used with curses.A_REVERSE. (To be honest, I forgot why, probably
-        # has something to do with how highlighting focus works.)
-        bg_name = pair.split(',')[1].split(':')[1].upper()
-        fg_name = pair.split(',')[0].split(':')[1].upper()
+        bg_name = pair.split(',')[0].split(':')[1].upper()
+        fg_name = pair.split(',')[1].split(':')[1].upper()
         color_pair = {'id': len(self.config.keys()) + 1}
         try:
             color_pair['bg'] = eval('curses.COLOR_' + bg_name)
@@ -1957,27 +1954,27 @@ class Interface(object):
         self.pad.addch(curses.ACS_DARROW, (0, curses.A_BOLD)[torrent['downloadLimited']])
         rate = ('', scale_bytes(torrent['rateDownload']))[torrent['rateDownload']>0]
         self.pad.addstr(rate.rjust(self.rateDownload_width),
-                        curses.color_pair(self.colors.id('download_rate')) + curses.A_BOLD + curses.A_REVERSE)
+                        curses.color_pair(self.colors.id('download_rate')) + curses.A_BOLD)
 
     def draw_uploadrate(self, torrent, ypos):
         self.pad.move(ypos, self.width-self.rateUpload_width-1)
         self.pad.addch(curses.ACS_UARROW, (0, curses.A_BOLD)[torrent['uploadLimited']])
         rate = ('', scale_bytes(torrent['rateUpload']))[torrent['rateUpload']>0]
         self.pad.addstr(rate.rjust(self.rateUpload_width),
-                        curses.color_pair(self.colors.id('upload_rate')) + curses.A_BOLD + curses.A_REVERSE)
+                        curses.color_pair(self.colors.id('upload_rate')) + curses.A_BOLD)
 
     def draw_ratio(self, torrent, ypos):
         self.pad.addch(ypos+1, self.width-self.rateUpload_width-1, curses.ACS_DIAMOND,
                        (0, curses.A_BOLD)[torrent['uploadRatio'] < 1 and torrent['uploadRatio'] >= 0])
         self.pad.addstr(ypos+1, self.width-self.rateUpload_width,
                         num2str(torrent['uploadRatio'], '%.02f').rjust(self.rateUpload_width),
-                        curses.color_pair(self.colors.id('eta+ratio')) + curses.A_BOLD + curses.A_REVERSE)
+                        curses.color_pair(self.colors.id('eta+ratio')) + curses.A_BOLD)
 
     def draw_eta(self, torrent, ypos):
         self.pad.addch(ypos+1, self.width-self.rateDownload_width-self.rateUpload_width-3, curses.ACS_PLMINUS)
         self.pad.addstr(ypos+1, self.width-self.rateDownload_width-self.rateUpload_width-2,
                         scale_time(torrent['eta']).rjust(self.rateDownload_width),
-                        curses.color_pair(self.colors.id('eta+ratio')) + curses.A_BOLD + curses.A_REVERSE)
+                        curses.color_pair(self.colors.id('eta+ratio')) + curses.A_BOLD)
 
     def draw_torrentlist_title(self, torrent, focused, width, ypos):
         if (torrent['status'] == Transmission.STATUS_SEED
@@ -2017,11 +2014,11 @@ class Interface(object):
         else:
             color = 0
 
-        tag = curses.A_REVERSE
+        tag = 0
         tag_done = tag + color
         if focused:
-            tag += curses.A_BOLD
-            tag_done += curses.A_BOLD
+            tag += curses.A_BOLD + curses.A_REVERSE
+            tag_done += curses.A_BOLD + curses.A_REVERSE
 
         if self.torrentname_is_progressbar:
             bar_width = int(float(width) * (float(percentDone)/100))
@@ -2723,8 +2720,7 @@ class Interface(object):
             if self.filter_list:
                 self.screen.addstr("Filter:", curses.A_REVERSE)
                 self.screen.addstr("%s%s" % (('','not ')[self.filter_inverse], self.filter_list),
-                                   curses.color_pair(self.colors.id('filter_status'))
-                                   + curses.A_REVERSE)
+                                   curses.color_pair(self.colors.id('filter_status')))
 
             # show last sort order (if terminal size permits it)
             curpos_y, curpos_x = self.screen.getyx()
@@ -2732,7 +2728,7 @@ class Interface(object):
                 self.screen.addstr(" Sort by:", curses.A_REVERSE)
                 name = [name[1] for name in self.sort_options if name[0] == self.sort_orders[-1]['name']][0]
                 name = name.replace('_', '').lower()
-                curses_tags = curses.color_pair(self.colors.id('filter_status')) + curses.A_REVERSE
+                curses_tags = curses.color_pair(self.colors.id('filter_status'))
                 if self.sort_orders[-1]['reverse']:
                     self.screen.addch(curses.ACS_DARROW, curses_tags)
                 else:
@@ -2764,14 +2760,14 @@ class Interface(object):
         self.screen.addch(curses.ACS_DARROW, curses.A_REVERSE)
         self.screen.addstr(scale_bytes(self.stats['downloadSpeed']).rjust(self.rateDownload_width),
                            curses.color_pair(self.colors.id('download_rate'))
-                           + curses.A_REVERSE + curses.A_BOLD)
+                           + curses.A_BOLD)
         self.screen.addstr(limits['dn_limit'], curses.A_REVERSE)
         self.screen.addch(' ', curses.A_REVERSE)
         self.screen.addch(curses.ACS_UARROW, curses.A_REVERSE)
         self.screen.insstr(limits['up_limit'], curses.A_REVERSE)
         self.screen.insstr(scale_bytes(self.stats['uploadSpeed']).rjust(self.rateUpload_width),
                            curses.color_pair(self.colors.id('upload_rate'))
-                           + curses.A_REVERSE + curses.A_BOLD)
+                           + curses.A_BOLD)
 
     def draw_title_bar(self):
         self.screen.insstr(0, 0, ' '.center(self.width), curses.A_REVERSE)
@@ -2952,8 +2948,7 @@ class Interface(object):
         win.keypad(True)
 
         if important:
-            win.bkgd(' ', curses.color_pair(self.colors.id('dialog_important'))
-                          + curses.A_REVERSE)
+            win.bkgd(' ', curses.color_pair(self.colors.id('dialog_important')))
 
         focus_tags   = curses.color_pair(self.colors.id('button_focused'))
         unfocus_tags = 0


### PR DESCRIPTION
I wanted to have transparent backgrounds in user-set colors.

Since all colors are parsed in reverse and then reversed later (as is stated in the helpful comment in line 182) this did not work. I took out this double-reversing so now you can get transparent background colors simply by specifying bg:,fg:something in the .cfg

I also changed the default config use bg: instead of bg:black and fg: instead of fg:white everywhere, since those are just the defaults (with the added benefit of getting transparent background now, e.g. for paused torrents)

The last change I made (which is not directly related to un-reversing colors) is the reversing of focused torrents (line 2023 / 2020) for better visibility.