### PR TITLE
Specify Destination Directory on Download

### DIFF
--- a/transmission-remote-cli
+++ b/transmission-remote-cli
@@ -569,6 +569,13 @@ class Transmission(object):
 
         return free # free space in bytes
 
+    def get_download_directory(self):
+        request = TransmissionRequest(self.host, self.port, self.path, 'session-get', self.TAG_SESSION_GET)
+        request.send_request()
+        response = request.get_response()
+        dir = response['arguments']['download-dir']
+	return dir
+
     def set_option(self, option_name, option_value):
         request = TransmissionRequest(self.host, self.port, self.path, 'session-set', 1, {option_name: option_value})
         request.send_request()
@@ -1257,7 +1264,7 @@ class Interface(object):
 
             destination = self.dialog_input_text("Destination directory"
                                 + (" - HDD (free): %.3f GB" % free_space if free_space else ""),
-                                        homedir2tilde(os.getcwd()+os.sep), tab_complete='files')
+                                        server.get_download_directory(), tab_complete='files')
 
             error = server.add_torrent(tilde2homedir(location),destination)
             if error:

--- a/transmission-remote-cli
+++ b/transmission-remote-cli
@@ -655,7 +655,7 @@ class Transmission(object):
     def toggle_turtle_mode(self):
         self.set_option('alt-speed-enabled', not self.status_cache['alt-speed-enabled'])
 
-    def add_torrent(self, location):
+    def add_torrent(self, location, destination):
         args = {}
         try:
             with  open(location, 'rb') as fp:
@@ -664,8 +664,10 @@ class Transmission(object):
         # be open by the server
         except IOError:
             args['filename'] = location
-
-        request = TransmissionRequest(self.host, self.port, self.path, 'torrent-add', 1, args)
+	
+	args['download-dir'] = destination
+        
+	request = TransmissionRequest(self.host, self.port, self.path, 'torrent-add', 1, args)
         request.send_request()
         response = request.get_response()
         if response['result'] != 'success':
@@ -1253,7 +1255,11 @@ class Interface(object):
             if re.match('^[0-9a-fA-F]{40}$', location):
                 location = 'magnet:?xt=urn:btih:{}'.format(location)
 
-            error = server.add_torrent(tilde2homedir(location))
+            destination = self.dialog_input_text("Destination directory"
+                                + (" - HDD (free): %.3f GB" % free_space if free_space else ""),
+                                        homedir2tilde(os.getcwd()+os.sep), tab_complete='files')
+
+            error = server.add_torrent(tilde2homedir(location),destination)
             if error:
                 msg = wrap("Couldn't add torrent \"%s\":" % location)
                 msg.extend(wrap(error, self.width-4))


### PR DESCRIPTION
When you are adding a new torrent, it will prompt you to specify the destination transmission should download the torrent to. The destination will be set to the default destination that is set within transmission by default.
