### PR TITLE
Added unit conversion for the Tebibyte (TiB, 2^40 B) suffix.

### DIFF
--- a/transmission-remote-cli
+++ b/transmission-remote-cli
@@ -3440,7 +3440,10 @@ def timestamp(timestamp, format="%x %X"):
 
 
 def scale_bytes(bytes, type='short'):
-    if bytes >= 1073741824:
+    if bytes >= 1099511627776:
+        scaled_bytes = round((bytes / 1099511627776.0), 2)
+        unit = 'T'
+    elif bytes >= 1073741824:
         scaled_bytes = round((bytes / 1073741824.0), 2)
         unit = 'G'
     elif bytes >= 1048576:


### PR DESCRIPTION
Any amount greater than 1099511627776 B (1 TiB) gets converted with 2 digit precision, similiar to the GiB conversion.